### PR TITLE
accomodate normal DateTime format

### DIFF
--- a/TvTime2Trakt/Trakt/TraktProcessor.cs
+++ b/TvTime2Trakt/Trakt/TraktProcessor.cs
@@ -99,7 +99,7 @@ internal class TraktProcessor
     {
         if (!string.IsNullOrWhiteSpace(episodeV2.CreatedAt))
         {
-            return DateTimeHelper.ConvertTvTimeDate(episodeV2.CreatedAt);
+            return DateTime.TryParse(episodeV2.CreatedAt, out DateTime date) ? date : DateTimeHelper.ConvertTvTimeDate(episodeV2.CreatedAt);
         }
 
         if (episode is not null && !string.IsNullOrWhiteSpace(episode.CreatedAt))


### PR DESCRIPTION
This seems to fix the issue I have reported by trying to parse it first before trying to convert it when it appears to have a different format. Let me know what you think